### PR TITLE
Fix TTS authorization header

### DIFF
--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -43,7 +43,8 @@ class VolcengineTTS:
         self.voice_type = voice_type
         self.host = host
         self.api_url = f"https://{host}/api/v1/tts"
-        self.header = {"Authorization": f"Bearer;{access_token}"}
+        # Use standard "Bearer" authorization header format
+        self.header = {"Authorization": f"Bearer {access_token}"}
 
     def text_to_speech(
         self,


### PR DESCRIPTION
## Summary
- fix malformed Authorization header when calling volcengine API

## Testing
- `python -m py_compile src/tools/tts.py`
