### PR TITLE
Fix requests.post payload handling

### DIFF
--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -104,7 +104,7 @@ class VolcengineTTS:
         try:
             logger.debug(f"Sending TTS request for text: {text[:50]}...")
             response = requests.post(
-                self.api_url, json.dumps(request_json), headers=self.header
+                self.api_url, json=request_json, headers=self.header
             )
             response_json = response.json()
 


### PR DESCRIPTION
## Summary
- send JSON payload in VolcengineTTS using `json=request_json`

## Testing
- `make lint` *(fails: No route to host)*
- `make format` *(fails: No route to host)*