### PR TITLE
Fix TTS header construction

### DIFF
--- a/src/tools/tts.py
+++ b/src/tools/tts.py
@@ -43,7 +43,7 @@ class VolcengineTTS:
         self.voice_type = voice_type
         self.host = host
         self.api_url = f"https://{host}/api/v1/tts"
-        self.header = {"Authorization": f"Bearer;{access_token}"}
+        self.header = {"Authorization": f"Bearer {access_token}"}
 
     def text_to_speech(
         self,

--- a/tests/integration/test_tts.py
+++ b/tests/integration/test_tts.py
@@ -29,7 +29,7 @@ class TestVolcengineTTS:
         assert tts.voice_type == "test_voice"
         assert tts.host == "test.host.com"
         assert tts.api_url == "https://test.host.com/api/v1/tts"
-        assert tts.header == {"Authorization": "Bearer;test_token"}
+        assert tts.header == {"Authorization": "Bearer test_token"}
 
     def test_initialization_with_defaults(self):
         """Test initialization with default values."""


### PR DESCRIPTION
## Summary
- fix Volcengine authorization header to use space instead of semicolon
- adjust unit test expectations

## Testing
- `make test` *(fails: failed to download `greenlet` due to network error)*